### PR TITLE
FIX: Avoid error for recursive :redir.

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -30,7 +30,7 @@ fu! recover#Recover(on) "{{{1
 endfu
 
 fu! s:Swapname() "{{{1
-    redir => a |sil swapname|redir end
+    sil! redir => a |sil swapname|redir end
     if a[1:] == 'No swap file'
 	return ''
     else


### PR DESCRIPTION
The s:CheckSwapFileExists() may be triggered while a command or mapping runs that :redirs itself. Unfortunately, recursive :redir is not allowed, and Vim throws an error, which negatively affects the original command / mapping. This has actually been reported by a user of my EnhancedJumps plugin (vimscript #2695).

Since an occasionally failing swapfile check isn't tragic, let's just suppress the error via :silent!.
