### PR TITLE
Do not set 'bexpr' for unrelated buffers.

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -116,6 +116,10 @@ fu! recover#DiffRecoveredFile() "{{{1
     diffthis
     let b:mod='recovered version'
     let l:filetype = &ft
+    if has("balloon_eval")
+	set ballooneval
+	setl bexpr=recover#BalloonExprRecover()
+    endif
     " saved version
     let curspr = &spr
     set nospr
@@ -132,13 +136,14 @@ fu! recover#DiffRecoveredFile() "{{{1
     setl noswapfile buftype=nowrite bufhidden=delete nobuflisted
     let b:mod='unmodified version on-disk'
     let swapbufnr=bufnr('')
+    if has("balloon_eval")
+	set ballooneval
+	setl bexpr=recover#BalloonExprRecover()
+    endif
     noa wincmd l
     let b:swapbufnr = swapbufnr
     command! -buffer RecoverPluginFinish :FinishRecovery
     command! -buffer FinishRecovery :call recover#RecoverFinish()
-    if has("balloon_eval")
-	set ballooneval bexpr=recover#BalloonExprRecover()
-    endif
     setl modified
 endfu
 
@@ -267,8 +272,8 @@ fu! recover#DiffRecoveredFileOld() "{{{2
 	call feedkeys(":command! -buffer FinishRecovery :call recover#RecoverFinish()\n", 't')
 	call feedkeys(":0\n", 't')
 	if has("balloon_eval")
-	"call feedkeys(':if has("balloon_eval")|:set ballooneval|set bexpr=recover#BalloonExprRecover()|endif'."\n", 't')
-	    call feedkeys(":set ballooneval|set bexpr=recover#BalloonExprRecover()\n", 't')
+	"call feedkeys(':if has("balloon_eval")|:set ballooneval|setl bexpr=recover#BalloonExprRecover()|endif'."\n", 't')
+	    call feedkeys(":set ballooneval|setl bexpr=recover#BalloonExprRecover()\n", 't')
 	endif
 	"call feedkeys(":redraw!\n", 't')
 	call feedkeys(":for i in range(".histnr.", histnr('cmd'), 1)|:call histdel('cmd',i)|:endfor\n",'t')


### PR DESCRIPTION
Users may have defined their own 'bexpr', and may want to keep that in all other buffers. Use :setlocal instead of :set to set the global-local option only for the on-disk and recovered buffers.
