### PR TITLE
Avoid aborting the diff when buffer was opened under try..catch.

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -56,7 +56,11 @@ fu! s:CheckRecover() "{{{1
 	let t = tempname()
 	" Doing manual recovery, otherwise, BufRead autocmd seems to
 	" get into the way of the recovery
-	exe 'recover' fnameescape(expand('%:p'))
+	try
+	    exe 'recover' fnameescape(expand('%:p'))
+	catch /^Vim\%((\a\+)\)\=:E/
+	    " Prevent any recovery error from disrupting the diff-split.
+	endtry
 	exe ':sil w' t
 	call system('diff '. shellescape(expand('%:p'),1).
 		    \ ' '. shellescape(t,1))


### PR DESCRIPTION
I use a custom :Drop command (that does some more magic), and use that almost exclusively to open files in Vim. Effectively, an :edit / :split command is issued under a try..catch block to catch and gracefully report any errors that occur during file open. Unfortunately, the try..catch changes the semantics inside s:CheckRecover(). When the :recover there fails with an E305, instead of continuing with the diff-split, the execution is aborted, and the plugin doesn't work for me.

The fix is to add a try..catch around :recover. It keeps the verbose recovery messages visible, so that there is still an indication when recovery failed.
