### PR TITLE
don't load user's vimrc when building vimball file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ undo:
 
 $(PLUGIN).vmb:
 	rm -f $(PLUGIN)-$(VERSION).vmb
-	vim -N -c 'ru! vimballPlugin.vim' -c ':call append("0", [ "$(SCRIPT)", "$(AUTOL)", "$(DOC)", "$(CVIM)"])' -c '$$d' -c ":%MkVimball $(PLUGIN)-$(VERSION)  ." -c':q!'
+	vim -N -u /dev/null -c 'ru! vimballPlugin.vim' -c ':call append("0", [ "$(SCRIPT)", "$(AUTOL)", "$(DOC)", "$(CVIM)"])' -c '$$d' -c ":%MkVimball $(PLUGIN)-$(VERSION)  ." -c':q!'
 	ln -f $(PLUGIN)-$(VERSION).vmb $(PLUGIN).vmb
 
 release: version all


### PR DESCRIPTION
This commit prevents the user's vimrc (which may be arbitrarily complex) from
being loaded into Vim when Vim is called to build the vimball file.
