### PR TITLE
`make` only builds; let user decide to un/install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION=$(shell sed -n '/Version:/{s/^.*\(\S\.\S\+\)$$/\1/;p}' $(SCRIPT))
 
 .PHONY: $(PLUGIN).vmb test
 
-all: uninstall vimball install 
+all: vimball
 
 vimball: $(PLUGIN).vmb
 


### PR DESCRIPTION
This patch changes make's default target so that running `make` only builds the vimball: let the _user_ decide whether to un/install it!
