### PR TITLE
$(PLUGIN).vmb is a real file, not a phony target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CVIM=$(wildcard contrib/*)
 PLUGIN=$(shell basename "$$PWD")
 VERSION=$(shell sed -n '/Version:/{s/^.*\(\S\.\S\+\)$$/\1/;p}' $(SCRIPT))
 
-.PHONY: $(PLUGIN).vmb test
+.PHONY: test
 
 all: vimball
 


### PR DESCRIPTION
This commit prevents the vimball from being built unconditionally.
