### PR TITLE
cvim: do not handle .swf as swap files

### DIFF
--- a/contrib/cvim
+++ b/contrib/cvim
@@ -263,7 +263,9 @@ if __name__ == '__main__':
 
     swaps = defaultdict(list)
     _swaps = []
-    swap_re = re.compile('\.sw[a-z]+$')
+    # Skip .swf files as these are usually for Flash
+    # TODO: print some warning
+    swap_re = re.compile('\.sw[a-eg-z]+$')
     for dir_ in args.directories:
         if args.recursive:
             os.chdir(os.path.abspath(dir_))


### PR DESCRIPTION
cvim used to handle .swf files as vim swap files and tried to recover from them. It failed, but it was annoying nonetheless. If someone has swap files up to .swf then he is totally busted and cvim does not help much here.