### PR TITLE
Fix bug where the '(D)elete' option wouldn't show in neovim

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -100,7 +100,7 @@ fu! recover#ConfirmSwapDiff() "{{{1
     let msg = ""
     let bufname = s:isWin() ? fnamemodify(expand('%'), ':p:8') : shellescape(expand('%'))
     let tfile = tempname()
-    if executable('vim') && !s:isWin() && !s:isMacTerm() && !get(g:, 'RecoverPlugin_No_Check_Swapfile', 0)
+    if executable(v:progpath) && !s:isWin() && !s:isMacTerm() && !get(g:, 'RecoverPlugin_No_Check_Swapfile', 0)
 	" Doesn't work on windows (system() won't be able to fetch the output)
 	" and Mac Terminal (issue #24)  
 	" Capture E325 Warning message
@@ -146,7 +146,7 @@ fu! recover#ConfirmSwapDiff() "{{{1
 	endif
     endif
     " Show modification message and present user question about what to do:
-    if executable('vim') && executable('diff') "&& s:isWin()
+    if executable(v:progpath) && executable('diff') "&& s:isWin()
 	" Check, whether the files differ issue #7
 	" doesn't work on Windows? (cmd is ok, should be executable)
 	if s:isWin()


### PR DESCRIPTION
Because the script uses executable('vim') to check various things, the
option to delete the swap file wasn't available on systems where Neovim
is installed but vim isn't. This commit fixes this bug.