### PR TITLE
Don't call uname on non-Unix system.

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -9,7 +9,7 @@
 
 let s:progpath=(v:version > 704 || (v:version == 704 && has("patch234")) ? v:progpath : 'vim')
 let s:swapinfo=exists("*swapinfo")
-let s:is_linux = system('uname') =~? 'linux'
+let s:is_linux = has("unix") && system('uname') =~? 'linux'
 
 fu! s:Swapname() "{{{1
   " Use sil! so a failing redir (e.g. recursive redir call)


### PR DESCRIPTION
To check if the current OS is Linux autoload/recover.vim executes `system('uname')` and checks its result against `'linux'`. On Windows this leads to flickering on the task bar, because vimrun.exe is called and Windows creates a task bar button for it.
We can prevent the flickering by checking for `has("unix")` first.