### PR TITLE
fix outdated name of psutils call

### DIFF
--- a/contrib/cvim
+++ b/contrib/cvim
@@ -164,7 +164,7 @@ class Swap(object):
 
         for process in psutil.process_iter():
             try:
-                files = process.get_open_files()
+                files = process.open_files()
             except psutil.AccessDenied:
                 files = []
             except psutil.error.NoSuchProcess:


### PR DESCRIPTION
get_open_files() was changed to open_files() in psutils 2.0.0 (2014)
see API changes on: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#200