### PR TITLE
Fix use of execute() to get swapname

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -18,7 +18,7 @@ fu! s:Swapname() "{{{1
   " Use sil! so a failing redir (e.g. recursive redir call)
   " won't hurt. (https://github.com/chrisbra/Recover.vim/pull/8)
   if exists('*execute')
-    let a=execute('swapname')
+    let a=trim(execute('swapname'))
   else
     sil! redir => a |sil swapname|redir end
   endif


### PR DESCRIPTION
The output of `execute('swapname')` includes a leading newline character which makes the `swapinfo()` call later on fail. Fixed by trimming the output.

```
:echo execute('swapname')

/path/to/afile.swp
```

```
:echo swapinfo(execute('swapname'))
{'error': 'Cannot open file'}
```

```
:echo swapinfo(trim(execute('swapname')))
{'pid': 1234, [...]}
```