### PR TITLE
Dont reset swapfile when not needed

### DIFF
--- a/autoload/recover.vim
+++ b/autoload/recover.vim
@@ -376,7 +376,7 @@ fu! s:ModifySTL(enable) "{{{1
   endif
 endfu
 fu! s:SetSwapfile() "{{{1
-  if &l:swf && !empty(bufname(''))
+  if &l:swf && !empty(bufname('')) && empty(&l:buftype)
     " Reset swapfile to use .swp extension
     sil setl noswapfile swapfile
   endif


### PR DESCRIPTION
This PR disables reseting `swapfile` setting for all buffers which have a non
empty `buftype`, maybe that's too much?  This is in particular anoying for
`terminal` buffers.
